### PR TITLE
Fix deadlock problem in node_processor close

### DIFF
--- a/services/hh/node_processor.go
+++ b/services/hh/node_processor.go
@@ -107,16 +107,17 @@ func (n *NodeProcessor) Open() error {
 // When closed it will not accept hinted-handoff data.
 func (n *NodeProcessor) Close() error {
 	n.mu.Lock()
-	defer n.mu.Unlock()
 
 	if n.done == nil {
 		// Already closed.
+		n.mu.Unlock()
 		return nil
 	}
 
 	close(n.done)
-	n.wg.Wait()
 	n.done = nil
+	n.mu.Unlock()
+	n.wg.Wait()
 
 	return n.queue.Close()
 }


### PR DESCRIPTION
**Which Issue(s) This PR Fixes**
Fixes https://github.com/chengshiwen/influxdb-cluster/issues/42

**Brief Description**
Resolve the dead lock in NodeProcess.Close() method.