### PR TITLE
BUGFIX: Close chan before wg.Wait cause close-event missing in NodeProcessor.

### DIFF
--- a/services/hh/node_processor.go
+++ b/services/hh/node_processor.go
@@ -107,16 +107,17 @@ func (n *NodeProcessor) Open() error {
 // When closed it will not accept hinted-handoff data.
 func (n *NodeProcessor) Close() error {
 	n.mu.Lock()
-	defer n.mu.Unlock()
 
 	if n.done == nil {
 		// Already closed.
+		n.mu.Unlock()
 		return nil
 	}
 
 	close(n.done)
-	n.wg.Wait()
 	n.done = nil
+	n.mu.Unlock()
+	n.wg.Wait()
 
 	return n.queue.Close()
 }


### PR DESCRIPTION
###### Description
In my last commit, a bug was introduced that setting chan point to nil before wg.Wait.
It will cause the goroutines select the chan (now it is nil), block forever.
Another dead-lock problem.

###### Modification
Use a closing var to prevent reentry of NodeProcessor.Close.
Move the setting chan to nil after wg.Wait
