### PR TITLE
fix: redirect /debug/pprof to avoid jumping to a blank page in httpd and meta service

### DIFF
--- a/services/httpd/pprof.go
+++ b/services/httpd/pprof.go
@@ -32,7 +32,7 @@ func (h *Handler) handleProfiles(w http.ResponseWriter, r *http.Request) {
 	case "/debug/pprof":
 		// Redirect to /debug/pprof/ to avoid jumping to a blank page
 		// after clicking the links on the /debug/pprof webpage.
-		http.Redirect(w, r, "/debug/pprof/", http.StatusFound)
+		http.Redirect(w, r, "/debug/pprof/", http.StatusTemporaryRedirect)
 	default:
 		httppprof.Index(w, r)
 	}

--- a/services/httpd/pprof.go
+++ b/services/httpd/pprof.go
@@ -29,6 +29,10 @@ func (h *Handler) handleProfiles(w http.ResponseWriter, r *http.Request) {
 		httppprof.Symbol(w, r)
 	case "/debug/pprof/all":
 		h.archiveProfilesAndQueries(w, r)
+	case "/debug/pprof":
+		// Add a redirect form /debug/pprof to /debug/pprof
+		// To fix the bug where users opening /debug/pprof are redirected to an empty link,
+		http.Redirect(w, r, "/debug/pprof/", http.StatusFound)
 	default:
 		httppprof.Index(w, r)
 	}

--- a/services/httpd/pprof.go
+++ b/services/httpd/pprof.go
@@ -30,8 +30,8 @@ func (h *Handler) handleProfiles(w http.ResponseWriter, r *http.Request) {
 	case "/debug/pprof/all":
 		h.archiveProfilesAndQueries(w, r)
 	case "/debug/pprof":
-		// Add a redirect form /debug/pprof to /debug/pprof
-		// To fix the bug where users opening /debug/pprof are redirected to an empty link,
+		// Redirect to /debug/pprof/ to avoid jumping to a blank page
+		// after clicking the links on the /debug/pprof webpage.
 		http.Redirect(w, r, "/debug/pprof/", http.StatusFound)
 	default:
 		httppprof.Index(w, r)

--- a/services/meta/pprof.go
+++ b/services/meta/pprof.go
@@ -28,7 +28,7 @@ func (h *handler) handleProfiles(w http.ResponseWriter, r *http.Request) {
 	case "/debug/pprof":
 		// Redirect to /debug/pprof/ to avoid jumping to a blank page
 		// after clicking the links on the /debug/pprof webpage.
-		http.Redirect(w, r, "/debug/pprof/", http.StatusFound)
+		http.Redirect(w, r, "/debug/pprof/", http.StatusTemporaryRedirect)
 	default:
 		httppprof.Index(w, r)
 	}

--- a/services/meta/pprof.go
+++ b/services/meta/pprof.go
@@ -25,6 +25,10 @@ func (h *handler) handleProfiles(w http.ResponseWriter, r *http.Request) {
 		httppprof.Symbol(w, r)
 	case "/debug/pprof/all":
 		h.archiveProfiles(w, r)
+	case "/debug/pprof":
+		// Redirect to /debug/pprof/ to avoid jumping to a blank page
+		// after clicking the links on the /debug/pprof webpage.
+		http.Redirect(w, r, "/debug/pprof/", http.StatusFound)
 	default:
 		httppprof.Index(w, r)
 	}


### PR DESCRIPTION
Which Issue(s) This PR Fixes
Fixes：修复打开/debug/pprof后，点击allocs， block， cmdline，goroutine， heap， mutex，profile， threadcreate，trace等超链接跳转出现404的bug

Brief Description
通过url重定向的方式，将/debug/pprof重定向至/debug/pprof/，避免浏览器在计算url路径时将pprof删除，导致url路径错误

- [*] Tests pass
测试已通过